### PR TITLE
feature: botões de Entrega e Coleta para o Gerente

### DIFF
--- a/frontend/src/components/dialogs/detalhes-reserva-dialog.tsx
+++ b/frontend/src/components/dialogs/detalhes-reserva-dialog.tsx
@@ -32,6 +32,7 @@ interface DetalhesReservaDialogProps {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   openClientDialog?: boolean
+  onOperacaoSucesso?: (reserva: Reserva, tipo: "Entrega" | "Coleta") => void
 }
 
 const formSchema = z
@@ -54,7 +55,7 @@ const formSchema = z
 
 type FormData = z.infer<typeof formSchema>;
 
-export const DetalhesReservaDialog = ({ reserva, tipo, children, open: controlledOpen, onOpenChange, openClientDialog }: DetalhesReservaDialogProps) => {
+export const DetalhesReservaDialog = ({ reserva, tipo, children, open: controlledOpen, onOpenChange, openClientDialog, onOperacaoSucesso }: DetalhesReservaDialogProps) => {
   const [isEditting, setIsEditting] = useState(false)
   const [internalOpen, setInternalOpen] = useState(false)
   const [clientDialogOpen, setClientDialogOpen] = useState(false)
@@ -319,7 +320,7 @@ export const DetalhesReservaDialog = ({ reserva, tipo, children, open: controlle
 
             <Dialog.Footer className="block space-y-3">
               {(isSuporte() || isGerente()) && tipo && (
-                <ConfirmarOperacaoDialog reserva={reserva} tipo={tipo}>
+                <ConfirmarOperacaoDialog reserva={reserva} tipo={tipo} onSuccess={onOperacaoSucesso}>
                   <Button className="w-full h-[2.625rem]">
                     Confirmar {tipo}
                   </Button>

--- a/frontend/src/components/dialogs/operacao-confirmada-dialog.tsx
+++ b/frontend/src/components/dialogs/operacao-confirmada-dialog.tsx
@@ -1,8 +1,5 @@
-import { updateReservaServer } from "@/redux/reservas/fetch";
 import { Dialog } from "../ui/dialog";
 import { type Reserva } from "@/redux/reservas/slice";
-import { useDispatch } from "react-redux";
-import { type AppDispatch } from "@/redux/store";
 
 interface OperacaoConfirmadaDialogProps {
     open: boolean
@@ -12,23 +9,8 @@ interface OperacaoConfirmadaDialogProps {
 }
 
 export const OperacaoConfirmadaDialog = ({ tipo, reserva, open, setOpen }: OperacaoConfirmadaDialogProps) => {
-    const dispatch = useDispatch<AppDispatch>()
-
-    const handleOpenChange = (isOpen: boolean) => {
-        const now = new Date().toISOString()
-
-        dispatch(updateReservaServer({
-            ...reserva,
-            dataEntrega: tipo === "Entrega" ? now : reserva.dataEntrega,
-            dataColeta: tipo === "Coleta" ? now : reserva.dataColeta,
-            status: tipo === "Coleta" ? "Concluída" : reserva.status,
-        }))
-
-        setOpen(isOpen)
-    }
-
     return tipo && (
-        <Dialog.Container open={open} onOpenChange={handleOpenChange}>
+        <Dialog.Container open={open} onOpenChange={setOpen}>
             <Dialog.Content>
                 <Dialog.Title>{tipo} confirmada!</Dialog.Title>
 

--- a/frontend/src/lib/fetch-utils.ts
+++ b/frontend/src/lib/fetch-utils.ts
@@ -69,3 +69,11 @@ export async function httpDelete<T = unknown>(
 ): Promise<T> {
   return fetchWrapper<T>(endpoint, { ...customConfig, method: 'DELETE' })
 }
+
+export async function httpPatch<T = unknown>(
+  endpoint: string,
+  body: unknown,
+  customConfig: Omit<FetchConfig, 'body' | 'method'> = {}
+): Promise<T> {
+  return fetchWrapper<T>(endpoint, { body, ...customConfig, method: 'PATCH' })
+}

--- a/frontend/src/pages/reservas.tsx
+++ b/frontend/src/pages/reservas.tsx
@@ -8,6 +8,7 @@ import { Separator } from "@/components/ui/separator";
 import { format, isToday, isTomorrow } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { DetalhesReservaDialog } from "@/components/dialogs/detalhes-reserva-dialog";
+import { OperacaoConfirmadaDialog } from "@/components/dialogs/operacao-confirmada-dialog";
 import useCargo from "@/hooks/useCargo";
 import { useNavigate, useLocation } from "react-router";
 import { useEffect, useState } from "react";
@@ -31,7 +32,7 @@ export default function ReservasPage() {
   const { status: statusR, error: errorR } = useSelector((rootReducer: RootState) => rootReducer.reservasReducer)
 
   useEffect(() => {
-    if (['not_loaded', 'saved', 'deleted'].includes(statusR)) {
+    if (['not_loaded', 'deleted'].includes(statusR)) {
       dispatch(fetchReservas())
     }
   }, [statusR, dispatch])
@@ -41,6 +42,7 @@ export default function ReservasPage() {
   const location = useLocation();
   const [reservaToOpen, setReservaToOpen] = useState<number | null>(null);
   const [clienteToOpen, setClienteToOpen] = useState<number | null>(null);
+  const [operacaoSucesso, setOperacaoSucesso] = useState<{ reserva: Reserva; tipo: "Entrega" | "Coleta" } | null>(null);
 
   useEffect(() => {
     if (!isGerente() && !isSuporte()) {
@@ -112,6 +114,7 @@ export default function ReservasPage() {
                         key={`${reserva.id}-${tipo}-${hora.getTime()}`} 
                         reserva={reserva} 
                         tipo={tipo}
+                        onOperacaoSucesso={(reserva, tipo) => setOperacaoSucesso({ reserva, tipo })}
                       >
                         <Card.Container>
                           <Card.TextContainer className="flex-1 truncate">
@@ -157,9 +160,19 @@ export default function ReservasPage() {
             }
           }}
           openClientDialog={clienteToOpen === reservaParaAbrir.cliente.id}
+          onOperacaoSucesso={(reserva, tipo) => setOperacaoSucesso({ reserva, tipo })}
         >
           <div style={{ display: 'none' }} />
         </DetalhesReservaDialog>
+      )}
+
+      {operacaoSucesso && (
+        <OperacaoConfirmadaDialog
+          reserva={operacaoSucesso.reserva}
+          tipo={operacaoSucesso.tipo}
+          open={true}
+          setOpen={(open) => !open && setOperacaoSucesso(null)}
+        />
       )}
     </PageContainer.List>
   );

--- a/frontend/src/redux/reservas/fetch.ts
+++ b/frontend/src/redux/reservas/fetch.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from "@reduxjs/toolkit"
 import { type Reserva, type NewReserva, type NewReservaServer, type ReservaServer } from "./slice"
-import { httpGet, httpPost, httpPut } from "@/lib/fetch-utils"
+import { httpGet, httpPatch, httpPost, httpPut } from "@/lib/fetch-utils"
 import { differenceInMilliseconds } from "date-fns"
 import { gerarCodigo } from "@/lib/gerar-codigo"
 
@@ -45,6 +45,43 @@ export const updateReservaServer = createAsyncThunk<Reserva, Reserva>('reservas/
     }
 
     return await httpPut(`/reservas/${reserva.id}`, updatedReserva)
+  }
+)
+
+export const entregarReservaServer = createAsyncThunk<Reserva, { reserva: Reserva; codigoEntrega: string }>('reservas/entregarReservaServer ',
+  async ({ reserva, codigoEntrega }) => {
+    const { cliente, pacote, endereco, ...reservaInfo } = reserva
+    const updatedReserva: ReservaServer = {
+      clienteId: reserva.cliente.id,
+      pacoteId: reserva.pacote.id,
+      enderecoId: reserva.endereco.id,
+      ...reservaInfo,
+      dataEntrega: new Date().toISOString(),
+    }
+
+    return await httpPatch(`/reservas/${reserva.id}`, updatedReserva)
+
+    // TODO: Quando tiver backend remover tudo acima e manter apenas:
+    // return await httpPatch(`/reservas/${reserva.id}/confirmar-entrega`, { codigoEntrega })
+  }
+)
+
+export const coletarReservaServer = createAsyncThunk<Reserva, { reserva: Reserva; codigoColeta: string }>('reservas/coletarReservaServer ',
+  async ({ reserva, codigoColeta }) => {
+    const { cliente, pacote, endereco, ...reservaInfo } = reserva
+    const updatedReserva: ReservaServer = {
+      clienteId: reserva.cliente.id,
+      pacoteId: reserva.pacote.id,
+      enderecoId: reserva.endereco.id,
+      ...reservaInfo,
+      dataColeta: new Date().toISOString(),
+      status: 'Concluída',
+    }
+
+    return await httpPatch(`/reservas/${reserva.id}`, updatedReserva)
+
+    // TODO: Quando tiver backend remover tudo acima e manter apenas:
+    // return await httpPatch(`/reservas/${reserva.id}/confirmar-coleta`, { codigoColeta })
   }
 )
 

--- a/frontend/src/redux/reservas/slice.ts
+++ b/frontend/src/redux/reservas/slice.ts
@@ -5,7 +5,7 @@ import type { Pacote } from "../pacotes/slice";
 import type { Endereco } from "@/redux/endereco/slice";
 import type { InitialState, RootState } from "../root-reducer";
 
-import {addReservaServer, cancelReservaServer, fetchReservas, updateReservaServer} from "./fetch";
+import {addReservaServer, cancelReservaServer, coletarReservaServer, entregarReservaServer, fetchReservas, updateReservaServer} from "./fetch";
 
 export type Reserva = {
   id: number
@@ -54,18 +54,24 @@ const reservasSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
-          .addCase(fetchReservas.pending,         (state, action) => { state.status = 'loading' })
-          .addCase(fetchReservas.fulfilled,       (state, action) => { state.status = 'loaded'; reservasAdapter.setAll(state, action.payload) })
-          .addCase(fetchReservas.rejected,        (state, action) => { state.status = 'failed'; state.error = 'Falha ao buscar reservas!' })
-          .addCase(addReservaServer.pending,      (state, action) => { state.status = 'saving' })
-          .addCase(addReservaServer.fulfilled,    (state, action) => { state.status = 'saved'; })
-          .addCase(addReservaServer.rejected,     (state, action) => { state.status = 'failed'; state.error = 'Falha ao adicionar reserva!' })
-          .addCase(updateReservaServer.pending,   (state, action) => { state.status = 'saving' })
-          .addCase(updateReservaServer.fulfilled, (state, action) => { state.status = 'saved';  reservasAdapter.upsertOne(state, action.payload) })
-          .addCase(updateReservaServer.rejected,  (state, action) => { state.status = 'failed'; state.error = 'Falha ao atualizar reserva!' })
-          .addCase(cancelReservaServer.pending,   (state, action) => { state.status = 'deleting' })
-          .addCase(cancelReservaServer.fulfilled, (state, action) => { state.status = 'deleted'; reservasAdapter.upsertOne(state, action.payload) })
-          .addCase(cancelReservaServer.rejected,  (state, action) => { state.status = 'failed';  state.error = 'Falha ao cancelar reserva!' })
+          .addCase(fetchReservas.pending,           (state, action) => { state.status = 'loading' })
+          .addCase(fetchReservas.fulfilled,         (state, action) => { state.status = 'loaded'; reservasAdapter.setAll(state, action.payload) })
+          .addCase(fetchReservas.rejected,          (state, action) => { state.status = 'failed'; state.error = 'Falha ao buscar reservas!' })
+          .addCase(addReservaServer.pending,        (state, action) => { state.status = 'saving' })
+          .addCase(addReservaServer.fulfilled,      (state, action) => { state.status = 'saved'; })
+          .addCase(addReservaServer.rejected,       (state, action) => { state.status = 'failed'; state.error = 'Falha ao adicionar reserva!' })
+          .addCase(updateReservaServer.pending,     (state, action) => { state.status = 'saving' })
+          .addCase(updateReservaServer.fulfilled,   (state, action) => { state.status = 'saved';  reservasAdapter.upsertOne(state, action.payload) })
+          .addCase(updateReservaServer.rejected,    (state, action) => { state.status = 'failed'; state.error = 'Falha ao atualizar reserva!' })
+          .addCase(entregarReservaServer.pending,   (state, action) => { state.status = 'saving' })
+          .addCase(entregarReservaServer.fulfilled, (state, action) => { state.status = 'saved';  reservasAdapter.upsertOne(state, action.payload) })
+          .addCase(entregarReservaServer.rejected,  (state, action) => { state.status = 'failed'; state.error = 'Falha ao confirmar entrega da reserva!' })
+          .addCase(coletarReservaServer.pending,    (state, action) => { state.status = 'saving' })
+          .addCase(coletarReservaServer.fulfilled,  (state, action) => { state.status = 'saved';  reservasAdapter.upsertOne(state, action.payload) })
+          .addCase(coletarReservaServer.rejected,   (state, action) => { state.status = 'failed'; state.error = 'Falha ao confirmar coleta da reserva!' })
+          .addCase(cancelReservaServer.pending,     (state, action) => { state.status = 'deleting' })
+          .addCase(cancelReservaServer.fulfilled,   (state, action) => { state.status = 'deleted'; reservasAdapter.upsertOne(state, action.payload) })
+          .addCase(cancelReservaServer.rejected,    (state, action) => { state.status = 'failed';  state.error = 'Falha ao cancelar reserva!' })
     
   }
 })


### PR DESCRIPTION
### O que foi feito

#### Adição dos Botões de 'Confirmar Entrega' e 'Confirmar Coleta' para o Gerente no dialog de Detalhes da Reserva
  - Os botões de 'Confirmar Entrega/Coleta' agora também aparecem para o Gerente (antes visível apenas para o Suporte).
  - Adicionados dois inputs para que o Gerente possa visualizar/editar os códigos de Entrega e Coleta da reserva, permitindo confirmar uma entrega/coleta a qualquer momento.
  
#### Novas funções de fetch e alterações no slice de Reservas
  - Adicionadas funções `entregarReservaServer` e `coletarReservaServer`, ambas utilizam o método PATCH, antes era utilizada a função `updateReservaServer` para confirmar uma entrega/coleta.
  - Dialog `confirmar-operacao-dialog.tsx` atualizado para usar as novas funções.
 
#### Melhorada a lógica de aparição do dialog de 'Operação Confirmada'
  - Ajustes na página `reservas.tsx` e nos dialogs (`detalhes-reserva-dialog.tsx`, `confirmar-operacao-dialog.tsx`, `operacao-confirmada-dialog`) para garantir que o dialog de **'Operação Confirmada'** apareça corretamente após entrega/coleta.

### Finalidade do PR
Integração das mudanças na atual develop.
